### PR TITLE
Fix reusable Codegen workflow reference

### DIFF
--- a/.github/workflows/codegen-on-issue.yml
+++ b/.github/workflows/codegen-on-issue.yml
@@ -59,7 +59,7 @@ jobs:
   call-reusable:
     if: ${{ needs.parse.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch' }}
     needs: parse
-    uses: dscv101/.github/.github/workflows/codegen-agents.yml@main
+    uses: dscv101/.github/.github/workflows/codegen-agentos.yml@main
     permissions:
       contents: read
     secrets:

--- a/.github/workflows/codegen-on-push.yml
+++ b/.github/workflows/codegen-on-push.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   call-reusable:
-    uses: dscv101/.github/.github/workflows/codegen-agents.yml@main
+    uses: dscv101/.github/.github/workflows/codegen-agentos.yml@main
     permissions:
       contents: read
     secrets:

--- a/.github/workflows/seed-agentos.yml
+++ b/.github/workflows/seed-agentos.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call-reusable:
-    uses: dscv101/.github/.github/workflows/codegen-agents.yml@main
+    uses: dscv101/.github/.github/workflows/codegen-agentos.yml@main
     permissions:
       contents: read
     secrets:


### PR DESCRIPTION
## Summary
- update the issue, push, and seeding workflows to call the correct reusable Codegen AgentOS workflow

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd92c3b370832b9465cc2fc6405a48